### PR TITLE
Add instance to parts

### DIFF
--- a/config/base.cfg
+++ b/config/base.cfg
@@ -1,5 +1,4 @@
 [buildout]
-parts = instance
 extends =
     https://dist.plone.org/release/6.0.1/versions.cfg
     https://dist.plone.org/release/6.0.1/versions-ecosystem.cfg
@@ -8,6 +7,7 @@ extends =
 show-picked-versions = true
 newest = false
 parts =
+    instance
     supervisor
 
 [settings]

--- a/config/base.cfg
+++ b/config/base.cfg
@@ -7,7 +7,6 @@ extends =
 show-picked-versions = true
 newest = false
 parts =
-    instance
     supervisor
 
 [settings]

--- a/profiles/development.cfg
+++ b/profiles/development.cfg
@@ -6,6 +6,7 @@ extends =
 auto-checkout =
     recensio.plone
 parts +=
+    instance
     test
     omelette
 


### PR DESCRIPTION
Instance was previously overwritten and thus the `bin/instance` script not generated.

@ale-rt I wonder if we also need parts definitions for the instance profiles like:

```
parts +=
    instance1
    instance2
    instance3
    instance4
    worker
```