### PR TITLE
Add test eggs to omelette and scripts.

### DIFF
--- a/profiles/development.cfg
+++ b/profiles/development.cfg
@@ -32,8 +32,11 @@ environment = testenv
 
 [omelette]
 recipe = collective.recipe.omelette
-eggs = ${instance:eggs}
+eggs = ${test:eggs}
 ignores =
     bcrypt
     cffi
     cryptography
+
+[scripts]
+eggs = ${test:eggs}


### PR DESCRIPTION
Add the test eggs to:

- omelette to also find test frameworks there

- scripts to have `zopepy` generated with test eggs which then allows to generate a complete config file with all package paths for vscode/vim language servers.