### PR TITLE
Longrequestlog and raven/sentry only for main instances

### DIFF
--- a/profiles/prod.cfg
+++ b/profiles/prod.cfg
@@ -26,14 +26,9 @@ verbose-security = off
 zserver-threads = 1
 zeo-client-cache-size = 500MB
 zodb-cache-size = 40000
-eggs +=
-    Products.LongRequestLogger[standalone]
 environment-vars +=
     zope_i18n_compile_mo_files true
     RUN_SHELL_COMMANDS true
-    longrequestlogger_file ${buildout:directory}/var/log/${:_buildout_section_name_}-longrequest.log
-    longrequestlogger_timeout 4
-    longrequestlogger_interval 2
     MEMCACHE_SERVER 195.62.125.219:11211
 zcml-additional =
     <include package="plone.app.async" file="multi_db_instance.zcml" />
@@ -51,6 +46,16 @@ zope-conf-additional +=
         </zeoclient>
         mount-point /zasync
     </zodb_db>
+scripts =
+
+[prod-instance-settings]
+<= instance-settings
+eggs +=
+    Products.LongRequestLogger[standalone]
+environment-vars +=
+    longrequestlogger_file ${buildout:directory}/var/log/${:_buildout_section_name_}-longrequest.log
+    longrequestlogger_timeout 4
+    longrequestlogger_interval 2
 event-log-custom = 
   %import raven.contrib.zope
   <logfile>
@@ -61,17 +66,11 @@ event-log-custom =
     dsn ${settings:sentry-dsn}
     level ERROR
   </sentry>
-scripts =
 
 [instance]
 <= instance-settings
 verbose-security = on
 zserver-threads = 2
-event-log-custom = 
-  <logfile>
-    path ${buildout:directory}/var/log/${:_buildout_section_name_}.log
-    level INFO
-  </logfile>
 
 [manager-instance]
 event-log-custom = 
@@ -82,11 +81,21 @@ http-address = ${settings:instancebots-address}
 zserver-threads = 4
 zeo-client-cache-size = 100MB
 zodb-cache-size = 10000
-event-log-custom = 
-  <logfile>
-    path ${buildout:directory}/var/log/${:_buildout_section_name_}.log
-    level INFO
-  </logfile>
+
+[instance1]
+<= prod-instance-settings
+
+[instance2]
+<= prod-instance-settings
+
+[instance3]
+<= prod-instance-settings
+
+[instance4]
+<= prod-instance-settings
+
+[worker]
+<= prod-instance-settings
 
 
 [supervisor]


### PR DESCRIPTION
Production: Only activate longrequestlog and raven/sentry for the main instances (instance1-4)

Especially instancebots should not have a longrequestlog as it grows pretty quickly and we don't care whether the bots have to wait.

syslabcom/scrum#1676