### PR TITLE
Use plone.recipe.zope2instance==6.13.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ py3/bin/buildout: py3/bin/pip3 requirements.txt $(wildcard config/*.txt)
 	# ... and reinstall it later
 	./py3/bin/pip3 install -IUr config/requirements-venv.txt -c config/constraints.txt
 	./py3/bin/pip3 install -IUr requirements.txt
-	./py3/bin/pip3 install plone.recipe.zope2instance==6.13.0
+	./py3/bin/pip list | grep "plone.recipe.zope2instance.*6.12.2$$" && ./py3/bin/pip3 install plone.recipe.zope2instance==6.13.0
 
 py3/bin/pip3:
 	python3 -m venv py3

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ py3/bin/buildout: py3/bin/pip3 requirements.txt $(wildcard config/*.txt)
 	# ... and reinstall it later
 	./py3/bin/pip3 install -IUr config/requirements-venv.txt -c config/constraints.txt
 	./py3/bin/pip3 install -IUr requirements.txt
+	./py3/bin/pip3 install plone.recipe.zope2instance==6.13.0
 
 py3/bin/pip3:
 	python3 -m venv py3


### PR DESCRIPTION
Is there a nicer way to override an individual entry in config/constraints.txt?

It's possible to specify the pip flag `-c` multiple times, but apparently it's only additive. If the constraints files conflict, you get an error.

I think mxdev can override constraints, but IIRC it just reads constraints files, processes them and writes new ones.

