### PR TITLE
Decrease the amount of logs spit out by the application

### DIFF
--- a/config/base.cfg
+++ b/config/base.cfg
@@ -80,12 +80,14 @@ zope-conf-additional =
             time 5s
         </monitorhandler>
     </requestmonitor>
-    <product-config timelogging>
-        filebase ${buildout:directory}/var/log/timelogging
-    </product-config>
-    <product-config successlogging>
-        filebase ${buildout:directory}/var/log/successlogging
-    </product-config>
+
+    ## Uncomment the following lines to get more insights
+    # <product-config timelogging>
+    #     filebase ${buildout:directory}/var/log/timelogging
+    # </product-config>
+    # <product-config successlogging>
+    #     filebase ${buildout:directory}/var/log/successlogging
+    # </product-config>
 
 [scripts]
 recipe = zc.recipe.egg


### PR DESCRIPTION
I think nobody is looking at them.

They are producing a huge amount of logs everyday.
I would argue that having this thing enabled causes more IO and even contributes to slow down the application.