### PR TITLE
Use Github CI to replace Jenkins

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,3 +33,6 @@ jobs:
           echo "[buildout]" > custom.cfg
           ln -s profiles/development.cfg buildout.cfg
           make
+      - name: Test
+        run: |
+          ./bin/test -s recensio.plone


### PR DESCRIPTION
These tests are already run in `recensio.plone`. Running them here as well ensures that the `recensio.plone` code also works correctly with the version pins provided in the buildout here.

This replaces the outdated Recensio setup on ci.syslab.com which still uses the old packages of before the Plone6 migration.